### PR TITLE
Fix #2 (endless loop on wrong input) and memory leak in `clexDeleteKinds()`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ clex is a simple lexer generator for C.
 
 With clex you can associate a regex pattern to each token type with `clexRegisterKind(regex, type)` call, pass the source using `clexInit(source)` call, and then lex the next token with `clex()` call.
 
+At the end of the input string, `clex()` returns `(Token){.lexeme = NULL, .kind = 0}`.
+
+The maximum number of rules is 1024, but you can change that number in `clex.h`: `#define CLEX_MAX_RULES 1024`
+
 ## Example
 
 ```c

--- a/clex.c
+++ b/clex.c
@@ -20,7 +20,7 @@ void clexInit(const char *content) {
   clexPosition = 0;
 }
 
-void clexRegisterKind(const char *re, int kind) {
+bool clexRegisterKind(const char *re, int kind) {
   if (!rules) {
     rules = calloc(CLEX_MAX_RULES, sizeof(Rule *));
   }
@@ -29,11 +29,13 @@ void clexRegisterKind(const char *re, int kind) {
       Rule *rule = malloc(sizeof(Rule));
       rule->re = re;
       rule->nfa = NFAFromRe(re);
+      if (!rule->nfa) return false;
       rule->kind = kind;
       rules[i] = rule;
       break;
     }
   }
+  return true;
 }
 
 void clexDeleteKinds() {

--- a/clex.c
+++ b/clex.c
@@ -21,9 +21,10 @@ void clexInit(const char *content) {
 }
 
 void clexRegisterKind(const char *re, int kind) {
-  if (!rules)
-    rules = calloc(1024, sizeof(Rule *));
-  for (int i = 0; i < 1024; i++) {
+  if (!rules) {
+    rules = calloc(CLEX_MAX_RULES, sizeof(Rule *));
+  }
+  for (int i = 0; i < CLEX_MAX_RULES; i++) {
     if (!rules[i]) {
       Rule *rule = malloc(sizeof(Rule));
       rule->re = re;
@@ -36,7 +37,7 @@ void clexRegisterKind(const char *re, int kind) {
 }
 
 void clexDeleteKinds() {
-  rules = calloc(1024, sizeof(Rule *));
+  if (rules) memset(rules, 0, CLEX_MAX_RULES);
 }
 
 Token clex() {
@@ -63,4 +64,3 @@ Token clex() {
   // EOF token is expected to have a kind=0 and a null string.
   return (Token){.lexeme = NULL, .kind = 0};
 }
-

--- a/clex.h
+++ b/clex.h
@@ -1,6 +1,8 @@
 #ifndef CLEX_H
 #define CLEX_H
 
+#define CLEX_MAX_RULES 1024
+
 typedef struct Token {
   int kind;
   char *lexeme;

--- a/clex.h
+++ b/clex.h
@@ -3,15 +3,16 @@
 
 #define CLEX_MAX_RULES 1024
 
+#include <stdbool.h>
+
 typedef struct Token {
   int kind;
   char *lexeme;
 } Token;
 
 void clexInit(const char *content);
-void clexRegisterKind(const char *re, int kind);
+bool clexRegisterKind(const char *re, int kind);
 void clexDeleteKinds(void);
 Token clex(void);
 
 #endif
-

--- a/fa.c
+++ b/fa.c
@@ -353,7 +353,9 @@ Node *NFAFromRe(const char *re) {
     if (token->kind == OSBRACKET) {
       int index = 0;
       Node *node = makeNode(false, true);
-      while (peek()->kind != CSBRACKET) {
+      int kind;
+      while ((kind = peek()->kind) != CSBRACKET) {
+        if (kind == EOF) return NULL;
         char fromValue = lex()->lexeme;
         if (peek()->kind == DASH) {
           lex();
@@ -394,4 +396,3 @@ bool NFATest(Node *nfa, const char *target) {
     return true;
   return false;
 }
-

--- a/fa.h
+++ b/fa.h
@@ -22,4 +22,3 @@ bool NFATest(Node *nfa, const char *target);
 void NFADraw(Node *nfa);
 
 #endif
-

--- a/tests.c
+++ b/tests.c
@@ -485,5 +485,8 @@ int main(int argc, char *argv) {
   assert(NFATest(nfa, "23") == true);
   assert(NFATest(nfa, "23u") == true);
   assert(NFATest(nfa, "23UlL") == true);
+
+  nfa = NFAFromRe("[");
+  assert(nfa == 0);
 }
 #endif


### PR DESCRIPTION
There are other memory leaks for instance when there is an error compiling the automaton, which might not be worth caring about if the automaton is built only once per process.

With these changes, `clexRegisterKind()` returns `false` to signal any error when building the automaton form the given regexp, which is notified to it by `NFAFromRe()` by returning `NULL`. 